### PR TITLE
fix: 데이터 요청 후 에러 발생 시 상태코드 명확하게 보이게 변경

### DIFF
--- a/src/api/httpRequest.ts
+++ b/src/api/httpRequest.ts
@@ -14,7 +14,7 @@ export class HttpRequest<T> {
   private readonly removeTimeInDate = (date: Date) => date.toISOString().substring(0, 10);
   private readonly operateError = (error: any) => {
     if (error.response) {
-      throw new Error(`2xx가 아닌 상태코드 ${error.response.status}로 응답했습니다 : `, error);
+      throw new Error(`2xx가 아닌 상태코드로 응답했습니다. 상태코드는 < ${error.response.status} > 입니다 : `, error);
     } else if (error.request) {
       throw new Error(`요청이 전송됐지만 응답이 수신되지 않습니다 : `, error);
     } else {


### PR DESCRIPTION
# 문제
코드는 멀쩡했는데 윈도우 권한 문제로 json-server가 실행되지 않아서 에러가 있었고 콘솔창에서 상태코드를 제대로 확인하지 못해서 문제 해결에 시간이 걸렸습니다.

# 해결
데이터 페치 모듈에서 에러를 반환할 때 상태코드가 더 명확하게 보이도록 수정했습니다.

- 수정 전 에러 메시지
<img width="731" alt="prev-error-message" src="https://user-images.githubusercontent.com/77876601/179903567-c966485e-234f-433f-82b3-68733eb2678a.png">

- 수정 후 에러 메시지
<img width="731" alt="improved-error-message" src="https://user-images.githubusercontent.com/77876601/179903570-a68dc5df-e67c-4bda-bb19-746c9ebed061.png">


# 참조
- 상태코드 0 : 타임아웃될 때까지 네트워크가 응답이 없는 경우

- [윈도우 에러](https://unit-15.tistory.com/83)